### PR TITLE
Pass the `SignatureRegistry` as an argument to where it's needed.

### DIFF
--- a/crates/api/src/instance.rs
+++ b/crates/api/src/instance.rs
@@ -4,7 +4,7 @@ use crate::runtime::{Config, Store};
 use crate::trap::Trap;
 use anyhow::{Error, Result};
 use wasmtime_jit::{CompiledModule, Resolver};
-use wasmtime_runtime::{Export, InstanceHandle, InstantiationError};
+use wasmtime_runtime::{Export, InstanceHandle, InstantiationError, SignatureRegistry};
 
 struct SimpleResolver<'a> {
     imports: &'a [Extern],
@@ -22,6 +22,7 @@ fn instantiate(
     config: &Config,
     compiled_module: &CompiledModule,
     imports: &[Extern],
+    sig_registry: &SignatureRegistry,
 ) -> Result<InstanceHandle, Error> {
     let mut resolver = SimpleResolver { imports };
     unsafe {
@@ -29,6 +30,7 @@ fn instantiate(
             .instantiate(
                 config.validating_config.operator_config.enable_bulk_memory,
                 &mut resolver,
+                sig_registry,
             )
             .map_err(|e| -> Error {
                 match e {
@@ -113,7 +115,12 @@ impl Instance {
     pub fn new(module: &Module, imports: &[Extern]) -> Result<Instance, Error> {
         let store = module.store();
         let config = store.engine().config();
-        let instance_handle = instantiate(config, module.compiled_module(), imports)?;
+        let instance_handle = instantiate(
+            config,
+            module.compiled_module(),
+            imports,
+            store.compiler().signatures(),
+        )?;
 
         let mut exports = Vec::with_capacity(module.exports().len());
         for export in module.exports() {

--- a/crates/jit/src/compiler.rs
+++ b/crates/jit/src/compiler.rs
@@ -11,7 +11,6 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_wasm::ModuleTranslationState;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::sync::Arc;
 use wasmtime_debug::{emit_debugsections_image, DebugInfoData};
 use wasmtime_environ::entity::{EntityRef, PrimaryMap};
 use wasmtime_environ::isa::{TargetFrontendConfig, TargetIsa};
@@ -54,7 +53,7 @@ pub struct Compiler {
 
     code_memory: CodeMemory,
     trap_registry: TrapRegistry,
-    signatures: Arc<SignatureRegistry>,
+    signatures: SignatureRegistry,
     strategy: CompilationStrategy,
     cache_config: CacheConfig,
 }
@@ -69,7 +68,7 @@ impl Compiler {
         Self {
             isa,
             code_memory: CodeMemory::new(),
-            signatures: Arc::new(SignatureRegistry::new()),
+            signatures: SignatureRegistry::new(),
             strategy,
             trap_registry: TrapRegistry::default(),
             cache_config,
@@ -240,7 +239,7 @@ impl Compiler {
     }
 
     /// Shared signature registry.
-    pub fn signatures(&self) -> &Arc<SignatureRegistry> {
+    pub fn signatures(&self) -> &SignatureRegistry {
         &self.signatures
     }
 

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -56,7 +56,6 @@ struct RawCompiledModule<'data> {
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,
     dbg_jit_registration: Option<GdbJitImageRegistration>,
     trap_registration: TrapRegistration,
-    sig_registry: Arc<SignatureRegistry>,
 }
 
 impl<'data> RawCompiledModule<'data> {
@@ -147,7 +146,6 @@ impl<'data> RawCompiledModule<'data> {
             signatures: signatures.into_boxed_slice(),
             dbg_jit_registration,
             trap_registration,
-            sig_registry: compiler.signatures().clone(),
         })
     }
 }
@@ -161,7 +159,6 @@ pub struct CompiledModule {
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,
     dbg_jit_registration: Option<Rc<GdbJitImageRegistration>>,
     trap_registration: TrapRegistration,
-    sig_registry: Arc<SignatureRegistry>,
 }
 
 impl CompiledModule {
@@ -186,7 +183,6 @@ impl CompiledModule {
             raw.signatures.clone(),
             raw.dbg_jit_registration,
             raw.trap_registration,
-            raw.sig_registry,
         ))
     }
 
@@ -199,7 +195,6 @@ impl CompiledModule {
         signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,
         dbg_jit_registration: Option<GdbJitImageRegistration>,
         trap_registration: TrapRegistration,
-        sig_registry: Arc<SignatureRegistry>,
     ) -> Self {
         Self {
             module: Arc::new(module),
@@ -209,7 +204,6 @@ impl CompiledModule {
             signatures,
             dbg_jit_registration: dbg_jit_registration.map(Rc::new),
             trap_registration,
-            sig_registry,
         }
     }
 
@@ -226,6 +220,7 @@ impl CompiledModule {
         &self,
         is_bulk_memory: bool,
         resolver: &mut dyn Resolver,
+        sig_registry: &SignatureRegistry,
     ) -> Result<InstanceHandle, InstantiationError> {
         let data_initializers = self
             .data_initializers
@@ -235,7 +230,7 @@ impl CompiledModule {
                 data: &*init.data,
             })
             .collect::<Vec<_>>();
-        let imports = resolve_imports(&self.module, &self.sig_registry, resolver)?;
+        let imports = resolve_imports(&self.module, &sig_registry, resolver)?;
         InstanceHandle::new(
             Arc::clone(&self.module),
             self.trap_registration.clone(),
@@ -302,7 +297,10 @@ pub unsafe fn instantiate(
     is_bulk_memory: bool,
     profiler: Option<&Arc<Mutex<Box<dyn ProfilingAgent + Send>>>>,
 ) -> Result<InstanceHandle, SetupError> {
-    let instance = CompiledModule::new(compiler, data, debug_info, profiler)?
-        .instantiate(is_bulk_memory, resolver)?;
+    let instance = CompiledModule::new(compiler, data, debug_info, profiler)?.instantiate(
+        is_bulk_memory,
+        resolver,
+        compiler.signatures(),
+    )?;
     Ok(instance)
 }


### PR DESCRIPTION
This avoids the need for storing it in an `Arc`.
